### PR TITLE
Have setuptools rename modules directory

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -6,11 +6,11 @@ A modular Python package for converting pfSense and OPNSense firewall rules into
 __version__ = "2.0.0"
 __author__ = "PyFRC2G Contributors"
 
-from modules.config import Config
-from modules.api_client import APIClient
-from modules.graph_generator import GraphGenerator
-from modules.ciso_client import CISOCClient
-from modules.utils import calculate_md5, extract_base_url, normalize_ports, safe_filename, map_value
+from .config import Config
+from .api_client import APIClient
+from .graph_generator import GraphGenerator
+from .ciso_client import CISOCClient
+from .utils import calculate_md5, extract_base_url, normalize_ports, safe_filename, map_value
 
 __all__ = [
     'Config',

--- a/modules/api_client.py
+++ b/modules/api_client.py
@@ -7,14 +7,14 @@ import urllib3
 import logging
 import traceback
 from requests.exceptions import RequestException, Timeout, ConnectionError, HTTPError
-from modules.utils import extract_base_url, update_api_maps
+from .utils import extract_base_url, update_api_maps
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class APIClient:
     """API client for firewall gateways"""
-    
+
     def __init__(self, config):
         self.config = config
         self.interface_map = {}
@@ -22,11 +22,11 @@ class APIClient:
         self.address_map = {}
         self.port_map = {}
         self.alias_details = {}  # Store full alias details: {alias_name: {type, content, description}}
-    
+
     def _handle_api_error(self, operation, url, error, log_level=logging.WARNING):
         """
         Centralized error handling for API requests.
-        
+
         Args:
             operation: Description of the operation (e.g., "fetch aliases")
             url: The URL that was requested
@@ -34,7 +34,7 @@ class APIClient:
             log_level: Logging level to use (default: WARNING)
         """
         error_type = type(error).__name__
-        
+
         if isinstance(error, Timeout):
             logging.log(log_level, f"Timeout while {operation} from {url}: {error}")
             logging.debug(f"Timeout details: {error}")
@@ -60,14 +60,14 @@ class APIClient:
             logging.log(log_level, f"Value error while {operation}: {error}")
         else:
             logging.log(log_level, f"Unexpected error ({error_type}) while {operation} from {url}: {error}")
-        
+
         if log_level == logging.DEBUG or logging.getLogger().isEnabledFor(logging.DEBUG):
             logging.debug(f"Full traceback:\n{traceback.format_exc()}")
-    
+
     def _make_api_request(self, url, method="GET", headers=None, auth=None, params=None, timeout=10, operation="API request"):
         """
         Make an API request with proper error handling.
-        
+
         Args:
             url: The URL to request
             method: HTTP method (default: GET)
@@ -76,7 +76,7 @@ class APIClient:
             params: Query parameters
             timeout: Request timeout in seconds
             operation: Description of the operation for error messages
-            
+
         Returns:
             Response object if successful, None otherwise
         """
@@ -91,18 +91,18 @@ class APIClient:
                 kwargs["auth"] = auth
             if params:
                 kwargs["params"] = params
-            
+
             response = requests.request(method, url, **kwargs)
-            
+
             # Check for HTTP errors (will raise HTTPError for 4xx/5xx status codes)
             try:
                 response.raise_for_status()
             except HTTPError:
                 # Re-raise to be caught by the outer exception handler
                 raise
-            
+
             return response
-            
+
         except Timeout as e:
             self._handle_api_error(operation, url, e, logging.ERROR)
             return None
@@ -121,7 +121,7 @@ class APIClient:
         except Exception as e:
             self._handle_api_error(operation, url, e, logging.ERROR)
             return None
-    
+
     def fetch_aliases(self):
         """Fetch all aliases from the configured gateway."""
         if self.config.gateway_type.lower() == "pfsense":
@@ -131,33 +131,33 @@ class APIClient:
         else:
             logging.error(f"Unknown gateway type: {self.config.gateway_type}")
             return {}, {}, {}, {}
-    
+
     def _fetch_pfsense_aliases(self):
         """Fetch all aliases from pfSense API."""
         base_url = self.config.pfs_base_url if self.config.pfs_base_url != "https://<PFS_ADDRESS>" else extract_base_url(self.config.pfs_url)
-        
+
         logging.debug(f"pfSense base URL: {base_url}")
-        
+
         # Fetch aliases
         alias_url = f"{base_url}/api/v2/firewall/aliases"
         logging.debug(f"Fetching aliases from: {alias_url}")
         headers = {"accept": "application/json", "X-API-Key": self.config.pfs_token}
         response = self._make_api_request(
-            alias_url, 
-            headers=headers, 
-            timeout=10, 
+            alias_url,
+            headers=headers,
+            timeout=10,
             operation="fetching pfSense aliases"
         )
-        
+
         if response:
             try:
                 data = response.json()
                 aliases = data.get("data", []) if isinstance(data, dict) else data
-                
+
                 if not isinstance(aliases, list):
                     logging.warning(f"Unexpected aliases data format: {type(aliases)}")
                     aliases = []
-                
+
                 for alias in aliases:
                     if not isinstance(alias, dict):
                         continue
@@ -173,7 +173,7 @@ class APIClient:
                     # Join addresses with comma and space
                     address_str = ", ".join(str(addr) for addr in address_list if addr)
                     description = alias.get("descr", "") or alias.get("name", "")
-                    
+
                     # Store alias details
                     self.alias_details[name] = {
                         "name": alias.get("name", ""),
@@ -181,37 +181,37 @@ class APIClient:
                         "content": address_str,
                         "description": description
                     }
-                    
+
                     if alias_type in ["host", "network"]:
                         self.net_map[name] = self.address_map[name] = description
                     elif alias_type == "port":
                         self.port_map[name] = address_str or description
                     else:
                         self.net_map[name] = description
-                
+
                 logging.info(f"✓ Retrieved {len(aliases)} aliases from pfSense API")
             except (ValueError, KeyError, TypeError) as e:
                 logging.error(f"Error parsing pfSense aliases response: {e}")
                 logging.debug(f"Response data: {response.text[:500] if hasattr(response, 'text') else 'N/A'}")
-        
+
         # Fetch interfaces
         iface_url = f"{base_url}/api/v2/interfaces"
         headers = {"accept": "application/json", "X-API-Key": self.config.pfs_token}
         response = self._make_api_request(
-            iface_url, 
-            headers=headers, 
-            timeout=10, 
+            iface_url,
+            headers=headers,
+            timeout=10,
             operation="fetching pfSense interfaces"
         )
         if response:
             try:
                 data = response.json()
                 interfaces = data.get("data", []) if isinstance(data, dict) else data
-                
+
                 if not isinstance(interfaces, list):
                     logging.warning(f"Unexpected interfaces data format: {type(interfaces)}")
                     interfaces = []
-                
+
                 for iface in interfaces:
                     if not isinstance(iface, dict):
                         continue
@@ -227,21 +227,21 @@ class APIClient:
                         else:
                             self.interface_map[identifier_lower] = identifier.upper()
                             logging.debug(f"Mapped interface (no descr): {identifier_lower} -> {identifier.upper()}")
-                
+
                 logging.info(f"✓ Retrieved {len(interfaces)} interfaces from pfSense API")
             except (ValueError, KeyError, TypeError) as e:
                 logging.warning(f"Error parsing pfSense interfaces response: {e}")
                 logging.debug(f"Response data: {response.text[:500] if hasattr(response, 'text') else 'N/A'}")
-        
+
         update_api_maps(self.interface_map, self.net_map, self.address_map, self.port_map, self.alias_details)
         return self.interface_map, self.net_map, self.address_map, self.port_map
-    
+
     def _fetch_opnsense_aliases(self):
         """Fetch all aliases from OPNSense API."""
         base_url = self.config.opns_base_url if self.config.opns_base_url != "https://<OPNS_ADDRESS>" else extract_base_url(self.config.opns_url)
-        
+
         logging.debug(f"OPNSense base URL: {base_url}")
-        
+
         # Fetch aliases
         alias_url = f"{base_url}/api/firewall/alias/get"
         logging.debug(f"Fetching aliases from: {alias_url}")
@@ -251,7 +251,7 @@ class APIClient:
             timeout=10,
             operation="fetching OPNSense aliases"
         )
-        
+
         if response:
             try:
                 data = response.json()
@@ -259,47 +259,47 @@ class APIClient:
                 alias_container = data.get("alias", {})
                 aliases_dict = alias_container.get("aliases", {})
                 aliases = aliases_dict.get("alias", {}) if isinstance(aliases_dict, dict) else {}
-                
+
                 if not isinstance(aliases, dict):
                     logging.warning(f"Unexpected aliases data format: {type(aliases)}")
                     aliases = {}
-                
+
                 logging.debug(f"Found {len(aliases)} aliases in response")
-                
+
                 processed_count = 0
                 for uuid, alias_data in aliases.items():
                     if not isinstance(alias_data, dict):
                         continue
-                    
+
                     # Check if alias is enabled
                     enabled = alias_data.get("enabled", "0")
                     if enabled != "1":
                         logging.debug(f"Skipping disabled alias: {alias_data.get('name', uuid)}")
                         continue
-                    
+
                     alias_name = alias_data.get("name", "")
                     if not alias_name:
                         continue
-                    
+
                     name = alias_name.lower()
                     description = alias_data.get("description", "") or alias_name
-                    
+
                     # Determine alias type by checking which type has selected=1
                     type_info = alias_data.get("type", {})
                     if not isinstance(type_info, dict):
                         continue
-                    
+
                     alias_type = None
                     for type_key, type_value in type_info.items():
                         if isinstance(type_value, dict) and type_value.get("selected", 0) == 1:
                             alias_type = type_key
                             break
-                    
+
                     # Only process host, network, and port types
                     if alias_type not in ["host", "network", "port"]:
                         logging.debug(f"Skipping alias '{alias_name}' with unsupported type: {alias_type}")
                         continue
-                    
+
                     # Extract content values (items with selected=1)
                     content = alias_data.get("content", {})
                     content_values = []
@@ -309,9 +309,9 @@ class APIClient:
                                 value = content_item.get("value", content_key)
                                 if value:
                                     content_values.append(str(value))
-                    
+
                     content_str = ", ".join(content_values) if content_values else ""
-                    
+
                     # Store alias details
                     self.alias_details[name] = {
                         "name": alias_name,
@@ -319,7 +319,7 @@ class APIClient:
                         "content": content_str,
                         "description": description
                     }
-                    
+
                     # Map to appropriate dictionaries
                     if alias_type in ["host", "network"]:
                         self.net_map[name] = self.address_map[name] = description
@@ -327,14 +327,14 @@ class APIClient:
                     elif alias_type == "port":
                         self.port_map[name] = content_str or description
                         logging.debug(f"Mapped port alias '{alias_name}': {content_str or description}")
-                    
+
                     processed_count += 1
-                
+
                 logging.info(f"✓ Retrieved {processed_count} aliases from OPNSense API (host/network/port types only)")
             except (ValueError, KeyError, TypeError) as e:
                 logging.error(f"Error parsing OPNSense aliases response: {e}")
                 logging.debug(f"Response data: {response.text[:500] if hasattr(response, 'text') else 'N/A'}")
-        
+
         # Fetch interfaces using the correct endpoint
         iface_url = f"{base_url}/api/interfaces/overview/interfaces_info"
         response = self._make_api_request(
@@ -343,16 +343,16 @@ class APIClient:
             timeout=10,
             operation="fetching OPNSense interfaces"
         )
-        
+
         if response:
             try:
                 data = response.json()
                 rows = data.get("rows", []) if isinstance(data, dict) else []
-                
+
                 if not isinstance(rows, list):
                     logging.warning(f"Unexpected interfaces data format: {type(rows)}")
                     rows = []
-                
+
                 for row in rows:
                     if isinstance(row, dict):
                         identifier = row.get("identifier", "").lower()
@@ -364,9 +364,9 @@ class APIClient:
                             if isinstance(config, dict):
                                 description = config.get("descr", "").strip()
                         enabled = row.get("enabled", False)
-                        
+
                         # Skip system interfaces and disabled interfaces
-                        if (identifier and 
+                        if (identifier and
                             identifier not in ["lo0", "enc0", "pflog0", ""] and
                             enabled):
                             # Always use description if available, fallback to identifier.upper() only if description is empty
@@ -376,15 +376,15 @@ class APIClient:
                             else:
                                 self.interface_map[identifier] = identifier.upper()
                                 logging.debug(f"Mapped interface (no description): {identifier} -> {identifier.upper()}")
-                
+
                 logging.info(f"✓ Retrieved {len(self.interface_map)} interfaces from OPNSense API")
             except (ValueError, KeyError, TypeError) as e:
                 logging.warning(f"Error parsing OPNSense interfaces response: {e}")
                 logging.debug(f"Response data: {response.text[:500] if hasattr(response, 'text') else 'N/A'}")
-        
+
         update_api_maps(self.interface_map, self.net_map, self.address_map, self.port_map, self.alias_details)
         return self.interface_map, self.net_map, self.address_map, self.port_map
-    
+
     def fetch_rules(self):
         """Fetch firewall rules from the configured gateway."""
         if self.config.gateway_type.lower() == "pfsense":
@@ -394,7 +394,7 @@ class APIClient:
         else:
             logging.error(f"Unknown gateway type: {self.config.gateway_type}")
             return []
-    
+
     def _fetch_pfsense_rules(self):
         """Fetch firewall rules from pfSense."""
         # Auto-detect interfaces if not specified
@@ -412,10 +412,10 @@ class APIClient:
                 interfaces_to_process = []
         else:
             logging.info(f"Using {len(interfaces_to_process)} manually specified interfaces: {interfaces_to_process}")
-        
+
         all_entries = []
         seen_rule_ids = set()
-        
+
         # Method 1: Global rules (always try this first)
         logging.debug(f"Fetching pfSense global rules from: {self.config.pfs_url}")
         headers = {"accept": "application/json", "X-API-Key": self.config.pfs_token}
@@ -425,22 +425,22 @@ class APIClient:
             timeout=30,
             operation="fetching pfSense global rules"
         )
-        
+
         if response:
             try:
                 data = response.json()
                 all_rules = data.get("data", [])
-                
+
                 if not isinstance(all_rules, list):
                     logging.warning(f"Unexpected rules data format: {type(all_rules)}")
                     all_rules = []
-                
+
                 logging.info(f"  → {len(all_rules)} global rules retrieved")
-                
+
                 if not all_rules:
                     logging.warning("No rules found in global response. Check API credentials and URL.")
                     logging.debug(f"Response data: {data}")
-                
+
                 for entry in all_rules:
                     if not isinstance(entry, dict):
                         continue
@@ -451,7 +451,7 @@ class APIClient:
             except (ValueError, KeyError, TypeError) as e:
                 logging.error(f"Error parsing pfSense rules response: {e}")
                 logging.debug(f"Response data: {response.text[:500] if hasattr(response, 'text') else 'N/A'}")
-        
+
         # Method 2: Per-interface rules (if interfaces were specified or detected)
         if interfaces_to_process:
             for interface in interfaces_to_process:
@@ -468,22 +468,22 @@ class APIClient:
                     timeout=30,
                     operation=f"fetching pfSense rules for interface {interface}"
                 )
-                
+
                 if response:
                     try:
                         data = response.json()
                         entries = data.get("data", [])
-                        
+
                         if not isinstance(entries, list):
                             logging.warning(f"Unexpected rules data format for {interface}: {type(entries)}")
                             entries = []
-                        
+
                         # Filter entries by interface if API doesn't support filtering
                         if entries:
                             filtered_entries = [e for e in entries if isinstance(e, dict) and e.get("interface", "").lower() == interface.lower()]
                             entries = filtered_entries
                         logging.info(f"  → {len(entries)} rules found for {interface}")
-                        
+
                         for entry in entries:
                             if not isinstance(entry, dict):
                                 continue
@@ -496,7 +496,7 @@ class APIClient:
                         logging.debug(f"Response data: {response.text[:500] if hasattr(response, 'text') else 'N/A'}")
         else:
             logging.info("No specific interfaces to process, using global rules only")
-        
+
         if all_entries:
             logging.info(f"✓ Total of {len(all_entries)} unique rules retrieved")
         else:
@@ -505,9 +505,9 @@ class APIClient:
             logging.error("  2. API URL is correct")
             logging.error("  3. Firewall allows API access from this IP")
             logging.error("  4. Run with --debug flag for more details")
-        
+
         return all_entries
-    
+
     def _fetch_opnsense_rules(self):
         """Fetch firewall rules from OPNSense."""
         # Auto-detect interfaces if not specified
@@ -525,10 +525,10 @@ class APIClient:
                 interfaces_to_process = []
         else:
             logging.info(f"Using {len(interfaces_to_process)} manually specified interfaces: {interfaces_to_process}")
-        
+
         all_entries = []
         seen_rule_ids = set()
-        
+
         # Method 1: Global rules (always try this first)
         logging.debug(f"Fetching OPNSense global rules from: {self.config.opns_url}")
         params = {"show_all": "1"}
@@ -539,22 +539,22 @@ class APIClient:
             timeout=30,
             operation="fetching OPNSense global rules"
         )
-        
+
         if response:
             try:
                 data = response.json()
                 all_rules = data.get("rows", [])
-                
+
                 if not isinstance(all_rules, list):
                     logging.warning(f"Unexpected rules data format: {type(all_rules)}")
                     all_rules = []
-                
+
                 logging.info(f"  → {len(all_rules)} global rules retrieved")
-                
+
                 if not all_rules:
                     logging.warning("No rules found in global response. Check API credentials and URL.")
                     logging.debug(f"Response data: {data}")
-                
+
                 for entry in all_rules:
                     if not isinstance(entry, dict):
                         continue
@@ -565,7 +565,7 @@ class APIClient:
             except (ValueError, KeyError, TypeError) as e:
                 logging.error(f"Error parsing OPNSense rules response: {e}")
                 logging.debug(f"Response data: {response.text[:500] if hasattr(response, 'text') else 'N/A'}")
-        
+
         # Method 2: Per-interface rules (if interfaces were specified or detected)
         if interfaces_to_process:
             for interface in interfaces_to_process:
@@ -579,18 +579,18 @@ class APIClient:
                     timeout=30,
                     operation=f"fetching OPNSense rules for interface {interface}"
                 )
-                
+
                 if response:
                     try:
                         data = response.json()
                         entries = data.get("rows", [])
-                        
+
                         if not isinstance(entries, list):
                             logging.warning(f"Unexpected rules data format for {interface}: {type(entries)}")
                             entries = []
-                        
+
                         logging.info(f"  → {len(entries)} rules found for {interface}")
-                        
+
                         for entry in entries:
                             if not isinstance(entry, dict):
                                 continue
@@ -603,7 +603,7 @@ class APIClient:
                         logging.debug(f"Response data: {response.text[:500] if hasattr(response, 'text') else 'N/A'}")
         else:
             logging.info("No specific interfaces to process, using global rules only")
-        
+
         if all_entries:
             logging.info(f"✓ Total of {len(all_entries)} unique rules retrieved")
         else:
@@ -612,16 +612,16 @@ class APIClient:
             logging.error("  2. API URL is correct")
             logging.error("  3. Firewall allows API access from this IP")
             logging.error("  4. Run with --debug flag for more details")
-        
+
         return all_entries
-    
+
     def _detect_pfsense_interfaces(self):
         """Auto-detect interface list from pfSense."""
         interfaces = set()
         base_api_url = self.config.pfs_base_url if self.config.pfs_base_url != "https://<PFS_ADDRESS>" else extract_base_url(self.config.pfs_url)
-        
+
         logging.debug(f"Attempting interface detection with base URL: {base_api_url}")
-        
+
         # Primary method: Use the correct pfSense endpoint
         endpoint = "/api/v2/interfaces"
         url = f"{base_api_url}{endpoint}"
@@ -633,20 +633,20 @@ class APIClient:
             timeout=10,
             operation="detecting pfSense interfaces (primary method)"
         )
-        
+
         if response:
             try:
                 data = response.json()
                 logging.debug(f"Response data structure: {type(data)}, keys: {list(data.keys()) if isinstance(data, dict) else 'N/A'}")
-                
+
                 interfaces_list = data.get("data", []) if isinstance(data, dict) else data
-                
+
                 if not isinstance(interfaces_list, list):
                     logging.warning(f"Unexpected interfaces data format: {type(interfaces_list)}")
                     interfaces_list = []
-                
+
                 logging.debug(f"Found {len(interfaces_list)} interface entries")
-                
+
                 for iface in interfaces_list:
                     if isinstance(iface, dict):
                         # Get interface identifier (id field: wan, lan, opt1, etc.)
@@ -655,9 +655,9 @@ class APIClient:
                         descr = iface.get("descr", "")
                         # Check if interface is enabled
                         enabled = iface.get("enable", True)  # Default to True if not specified
-                        
+
                         # Only add enabled interfaces, skip system interfaces
-                        if (identifier and 
+                        if (identifier and
                             identifier.lower() not in ["lo0", "enc0", "pflog0", ""] and
                             enabled):
                             identifier_lower = identifier.lower()
@@ -665,7 +665,7 @@ class APIClient:
                             interfaces.add(identifier_lower)
             except (ValueError, KeyError, TypeError) as e:
                 logging.debug(f"Error parsing pfSense interfaces response: {e}")
-        
+
         # Fallback method: Try v1 endpoint
         if not interfaces:  # Only try fallback if primary method didn't find interfaces
             endpoint = "/api/v1/firewall/interface"
@@ -678,7 +678,7 @@ class APIClient:
                 timeout=10,
                 operation="detecting pfSense interfaces (fallback method)"
             )
-            
+
             if response:
                 try:
                     data = response.json()
@@ -693,7 +693,7 @@ class APIClient:
                                         interfaces.add(if_name)
                 except (ValueError, KeyError, TypeError) as e:
                     logging.debug(f"Error parsing pfSense interfaces fallback response: {e}")
-        
+
         # Extract from firewall rules (most reliable method)
         if not interfaces:  # Only try this if other methods didn't find interfaces
             logging.debug("Attempting to extract interfaces from firewall rules...")
@@ -705,20 +705,20 @@ class APIClient:
                 timeout=10,
                 operation="extracting interfaces from pfSense rules"
             )
-            
+
             if response:
                 try:
                     data = response.json()
                     logging.debug(f"Rules response structure: {type(data)}, keys: {list(data.keys()) if isinstance(data, dict) else 'N/A'}")
-                    
+
                     rules = data.get("data", [])
-                    
+
                     if not isinstance(rules, list):
                         logging.warning(f"Unexpected rules data format: {type(rules)}")
                         rules = []
-                    
+
                     logging.debug(f"Found {len(rules)} rule entries")
-                    
+
                     for i, entry in enumerate(rules):
                         if isinstance(entry, dict):
                             # Check interface field
@@ -737,9 +737,9 @@ class APIClient:
                                                 interfaces.add(val)
                 except (ValueError, KeyError, TypeError) as e:
                     logging.debug(f"Error parsing pfSense rules for interface extraction: {e}")
-        
+
         logging.debug(f"All collected interface candidates: {sorted(interfaces)}")
-        
+
         # Filter and sort valid interfaces
         valid_interfaces = []
         for iface in interfaces:
@@ -752,24 +752,24 @@ class APIClient:
                     logging.debug(f"Accepted interface: {iface_str}")
                 else:
                     logging.debug(f"Rejected interface candidate: {iface_str} (doesn't match pattern)")
-        
+
         valid_interfaces = sorted(list(set(valid_interfaces)))
-        
+
         if valid_interfaces:
             logging.info(f"✓ Auto-detected interfaces: {valid_interfaces}")
             return valid_interfaces
-        
+
         logging.warning(f"No valid interfaces auto-detected. Collected candidates were: {sorted(interfaces)}")
         logging.warning("Please manually specify interfaces in config.py: INTERFACES = ['wan', 'lan', 'opt1', ...]")
         return []
-    
+
     def _detect_opnsense_interfaces(self):
         """Auto-detect interface list from OPNSense."""
         interfaces = set()
         base_api_url = self.config.opns_base_url if self.config.opns_base_url != "https://<OPNS_ADDRESS>" else extract_base_url(self.config.opns_url)
-        
+
         logging.debug(f"Attempting interface detection with base URL: {base_api_url}")
-        
+
         # Primary method: Use the correct OPNSense endpoint
         endpoint = "/api/interfaces/overview/interfaces_info"
         url = f"{base_api_url}{endpoint}"
@@ -780,39 +780,39 @@ class APIClient:
             timeout=10,
             operation="detecting OPNSense interfaces (primary method)"
         )
-        
+
         if response:
             try:
                 data = response.json()
                 logging.debug(f"Response data structure: {type(data)}, keys: {list(data.keys()) if isinstance(data, dict) else 'N/A'}")
-                
+
                 if isinstance(data, dict) and "rows" in data:
                     rows = data.get("rows", [])
-                    
+
                     if not isinstance(rows, list):
                         logging.warning(f"Unexpected interfaces data format: {type(rows)}")
                         rows = []
-                    
+
                     logging.debug(f"Found {len(rows)} interface entries in 'rows'")
-                    
+
                     for row in rows:
                         if isinstance(row, dict):
                             # Get identifier (wan, lan, etc.)
                             identifier = row.get("identifier", "")
                             enabled = row.get("enabled", False)
-                            
+
                             # Only add enabled interfaces, skip system interfaces
-                            if (identifier and 
+                            if (identifier and
                                 identifier not in ["lo0", "enc0", "pflog0", ""] and
                                 enabled):
                                 logging.debug(f"Found enabled interface identifier: {identifier}")
                                 interfaces.add(identifier)
-                            
+
                             # Also check config.if for device name mapping (as fallback)
                             config = row.get("config", {})
                             if isinstance(config, dict):
                                 if_name = config.get("if", "")
-                                if (if_name and 
+                                if (if_name and
                                     if_name not in ["lo0", "enc0", "pflog0"] and
                                     enabled and
                                     not identifier):  # Only use if no identifier found
@@ -820,9 +820,9 @@ class APIClient:
                                     interfaces.add(if_name)
             except (ValueError, KeyError, TypeError) as e:
                 logging.debug(f"Error parsing OPNSense interfaces response: {e}")
-        
 
-        
+
+
         # Extract from firewall rules (most reliable method)
         if not interfaces:  # Only try this if primary method didn't find interfaces
             logging.debug("Attempting to extract interfaces from firewall rules...")
@@ -835,20 +835,20 @@ class APIClient:
                 timeout=10,
                 operation="extracting interfaces from OPNSense rules"
             )
-            
+
             if response:
                 try:
                     data = response.json()
                     logging.debug(f"Rules response structure: {type(data)}, keys: {list(data.keys()) if isinstance(data, dict) else 'N/A'}")
-                    
+
                     rows = data.get("rows", [])
-                    
+
                     if not isinstance(rows, list):
                         logging.warning(f"Unexpected rules data format: {type(rows)}")
                         rows = []
-                    
+
                     logging.debug(f"Found {len(rows)} rule entries")
-                    
+
                     for i, entry in enumerate(rows):
                         if isinstance(entry, dict):
                             if "interface" in entry and entry["interface"]:
@@ -866,9 +866,9 @@ class APIClient:
                                                 interfaces.add(val)
                 except (ValueError, KeyError, TypeError) as e:
                     logging.debug(f"Error parsing OPNSense rules for interface extraction: {e}")
-        
+
         logging.debug(f"All collected interface candidates: {sorted(interfaces)}")
-        
+
         # Filter and sort valid interfaces
         valid_interfaces = []
         for iface in interfaces:
@@ -881,13 +881,13 @@ class APIClient:
                     logging.debug(f"Accepted interface: {iface_str}")
                 else:
                     logging.debug(f"Rejected interface candidate: {iface_str} (doesn't match pattern)")
-        
+
         valid_interfaces = sorted(list(set(valid_interfaces)))
-        
+
         if valid_interfaces:
             logging.info(f"✓ Auto-detected interfaces: {valid_interfaces}")
             return valid_interfaces
-        
+
         logging.warning(f"No valid interfaces auto-detected. Collected candidates were: {sorted(interfaces)}")
         logging.warning("Please manually specify interfaces in config.py: INTERFACES = ['wan', 'lan', 'opt1', ...]")
         return []

--- a/modules/config.py
+++ b/modules/config.py
@@ -37,7 +37,7 @@ ANY_VALUE = "Any"
 
 class Config:
     """Configuration class for PyFRC2G"""
-    
+
     def __init__(self):
         self.gateway_type = GATEWAY_TYPE
         # Use gateway name, or extract from URL if not set
@@ -46,7 +46,7 @@ class Config:
         else:
             # Will be set after determining firewall host
             self.gateway_name = None
-        
+
         # pfSense - Build URL from base URL
         self.pfs_base_url = PFS_BASE_URL
         if PFS_BASE_URL != "https://<PFS_ADDRESS>":
@@ -54,7 +54,7 @@ class Config:
         else:
             self.pfs_url = "https://<PFS_ADDRESS>/api/v2/firewall/rules"
         self.pfs_token = PFS_TOKEN
-        
+
         # OPNSense - Build URL from base URL
         self.opns_base_url = OPNS_BASE_URL
         if OPNS_BASE_URL != "https://<OPNS_ADDRESS>":
@@ -64,31 +64,31 @@ class Config:
         self.opns_secret = OPNS_SECRET
         self.opns_key = OPNS_KEY
         self.interfaces = INTERFACES
-        
+
         # Determine output directory from firewall address
-        from modules.utils import extract_host_from_url, extract_base_url
-        
+        from .utils import extract_host_from_url, extract_base_url
+
         if self.gateway_type.lower() == "pfsense":
             base_url = self.pfs_base_url if self.pfs_base_url != "https://<PFS_ADDRESS>" else extract_base_url(self.pfs_url)
         else:
             base_url = self.opns_base_url if self.opns_base_url != "https://<OPNS_ADDRESS>" else extract_base_url(self.opns_url)
-        
+
         firewall_host = extract_host_from_url(base_url)
-        
+
         # Set gateway_name if not already set
         if self.gateway_name is None:
             self.gateway_name = firewall_host
-        
+
         self.graph_output_dir = f"results/{self.gateway_name}"
         self.csv_file = f"output_{self.gateway_name}.csv"
-        
+
         # CISO Assistant Configuration
         self.ciso_url = CISO_URL
         self.ciso_token = CISO_TOKEN
         self.ciso_evidence_path = CISO_EVIDENCE_PATH
         self.ciso_folder_id = CISO_FORLDER_ID
         self.ciso_evidence_id = CISO_EVIDENCE_ID
-        
+
         # Constants
         self.csv_fieldnames = CSV_FIELDNAMES
         self.floating_rules_labels = FLOATING_RULES_LABELS

--- a/modules/graph_generator.py
+++ b/modules/graph_generator.py
@@ -8,63 +8,63 @@ import csv
 import logging
 from collections import OrderedDict
 from graphviz import Digraph
-from modules.utils import normalize_ports, safe_filename, map_value, format_alias_label
-from modules.config import FLOATING_RULES_LABELS, UNKNOWN_LABEL, DISABLED_LABEL, ANY_VALUE
+from .utils import normalize_ports, safe_filename, map_value, format_alias_label
+from .config import FLOATING_RULES_LABELS, UNKNOWN_LABEL, DISABLED_LABEL, ANY_VALUE
 
 
 class GraphGenerator:
     """Graph generator for firewall rules"""
-    
+
     def __init__(self, config):
         self.config = config
-    
+
     def generate_by_interface(self, csv_path, output_dir):
         """Generate separate CSV and PDF files for each interface."""
         os.makedirs(output_dir, exist_ok=True)
         rules_by_interface = OrderedDict()
-        
+
         # Group rules by interface
         with open(csv_path, newline='', encoding='utf-8') as f:
             reader = csv.DictReader(f)
             for row in reader:
                 gateway = (row.get("GATEWAY") or "").strip()
                 interface_name = gateway.split("/", 1)[1] if "/" in gateway else gateway
-                
+
                 if interface_name not in rules_by_interface:
                     rules_by_interface[interface_name] = []
                 rules_by_interface[interface_name].append(row)
-        
+
         # Generate files for each interface
         for interface_name, rules in rules_by_interface.items():
             if not rules:
                 continue
-            
+
             interface_safe = safe_filename(interface_name)
             logging.info(f"Processing interface: {interface_name} ({len(rules)} rules)")
-            
+
             # Extract host from output directory path (results/host/)
             host_name = os.path.basename(output_dir) if os.path.basename(output_dir) else "gateway"
-            
+
             # Create CSV file
             interface_csv = os.path.join(output_dir, f"{host_name}_{interface_safe}_flows.csv")
             with open(interface_csv, "w", newline="", encoding="utf-8") as f:
                 writer = csv.DictWriter(f, fieldnames=self.config.csv_fieldnames)
                 writer.writeheader()
                 writer.writerows(rules)
-            
+
             logging.info(f"  ✓ CSV created: {interface_csv}")
-            
+
             # Generate graph and PDF
             self.generate_graphs(interface_csv, output_dir, interface_name)
-        
+
         logging.info(f"✓ Generated files for {len(rules_by_interface)} interfaces")
-    
+
     def generate_graphs(self, csv_path, output_dir, interface_filter=None):
         """Parse CSV and generate graphs. If interface_filter is specified, only generate for that interface."""
         os.makedirs(output_dir, exist_ok=True)
         flows_by_gateway = OrderedDict()
         next_id = 0
-        
+
         def get_node(nodes, key, label=None, color=None, force_unique=False):
             """Create or retrieve a node, factorized by cluster/source unless force_unique."""
             nonlocal next_id
@@ -73,15 +73,15 @@ class GraphGenerator:
                 nodes[actual_key] = (f"node{next_id}", color, label or key)
                 next_id += 1
             return nodes[actual_key][0]
-        
+
         def get_action_color(action):
             """Get color for action type."""
             return "#a3f7a3" if action == "PASS" else "#f7a3a3" if action == "BLOCK" or action == "REJECT" else None
-        
+
         def get_disabled_color(disabled):
             """Get color for disabled rules."""
             return "#ffcc00" if disabled == "True" else None
-        
+
         # Parse CSV and build graph structure
         with open(csv_path, newline='', encoding='utf-8') as f:
             reader = csv.DictReader(f)
@@ -89,51 +89,51 @@ class GraphGenerator:
                 floating = (row.get("FLOATING") or "").strip()
                 source = (row.get("SOURCE") or "").strip()
                 gateway = (row.get("GATEWAY") or "").strip() if floating not in ["True", "1"] else "Floating-rules"
-                
+
                 # Filter by interface if specified
                 if interface_filter:
                     interface_name = gateway.split("/", 1)[1] if "/" in gateway else gateway
                     if interface_name != interface_filter:
                         continue
-                
+
                 action = (row.get("ACTION") or "").strip().upper()
                 protocol = (row.get("PROTOCOL") or "").strip() or ANY_VALUE
                 ports = normalize_ports(row.get("PORT"), ANY_VALUE)
                 destination = (row.get("DESTINATION") or "").strip()
                 comment = (row.get("COMMENT") or "").strip()
                 disabled = (row.get("DISABLED") or "").strip()
-                
+
                 # Create labels with alias details (clean HTML-like characters)
                 source_clean = str(source).replace('<', '').replace('>', '') if source else UNKNOWN_LABEL
                 gateway_clean = str(gateway).replace('<', '').replace('>', '') if gateway else UNKNOWN_LABEL
                 action_clean = str(action).replace('<', '').replace('>', '') if action else UNKNOWN_LABEL
                 destination_clean = str(destination).replace('<', '').replace('>', '') if destination else UNKNOWN_LABEL
                 comment_clean = str(comment).replace('<', '').replace('>', '') if comment else ""
-                
+
                 # Format labels with alias details if available
                 source_formatted = format_alias_label(source, source_clean)
                 destination_formatted = format_alias_label(destination, destination_clean)
                 port_formatted = format_alias_label(ports, ports)
-                
+
                 source_label = f"SOURCE | {source_formatted}" if source_formatted else f"SOURCE | {UNKNOWN_LABEL}"
                 gateway_label = f"GATEWAY | {gateway_clean}" if gateway_clean else f"GATEWAY | {UNKNOWN_LABEL}"
                 action_label = f"ACTION | {action_clean}" if action_clean else f"ACTION | {UNKNOWN_LABEL}"
                 proto_label = f"PROTOCOL | {protocol}"
                 port_label = f"PORT | {port_formatted}"
-                
+
                 if disabled == "True":
                     destination_label = f"{destination_formatted} | {comment_clean} | {DISABLED_LABEL}" if comment_clean else f"VLAN | {destination_formatted} | {DISABLED_LABEL}"
                 else:
                     destination_label = f"{destination_formatted} | {comment_clean}" if comment_clean else f"VLAN | {destination_formatted}"
-                
+
                 # Initialize cluster/source
                 if gateway not in flows_by_gateway:
                     flows_by_gateway[gateway] = OrderedDict()
                 if source not in flows_by_gateway[gateway]:
                     flows_by_gateway[gateway][source] = {"nodes": OrderedDict(), "edges": set()}
-                
+
                 cluster = flows_by_gateway[gateway][source]
-                
+
                 # Create nodes
                 n_source = get_node(cluster["nodes"], source_label)
                 n_gateway = get_node(cluster["nodes"], gateway_label)
@@ -142,17 +142,17 @@ class GraphGenerator:
                 n_proto = get_node(cluster["nodes"], proto_key, label=proto_label)
                 port_key = f"{ports}|{proto_key}"
                 n_port = get_node(cluster["nodes"], port_key, label=port_label)
-                
+
                 is_floating = any(label in gateway for label in FLOATING_RULES_LABELS)
-                n_destination = get_node(cluster["nodes"], destination_label, 
-                                        force_unique=not is_floating, 
+                n_destination = get_node(cluster["nodes"], destination_label,
+                                        force_unique=not is_floating,
                                         color=get_disabled_color(disabled))
-                
+
                 # Create edges
-                edges = [(n_source, n_gateway), (n_gateway, n_action), (n_action, n_proto), 
+                edges = [(n_source, n_gateway), (n_gateway, n_action), (n_action, n_proto),
                         (n_proto, n_port), (n_port, n_destination)]
                 cluster["edges"].update(edges)
-        
+
         # Generate graphs
         for gateway, sources in flows_by_gateway.items():
             gateway_safe = safe_filename(gateway)
@@ -167,74 +167,74 @@ class GraphGenerator:
             if not gateway_label:
                 gateway_label = "Gateway"
             g.attr(label=f"<<b>GATEWAY : {gateway_label}</b>>", labelloc="t", fontsize="14", color="#8888ff")
-            
+
             for source, cluster in sources.items():
                 with g.subgraph(name=f"cluster_{source.replace(' ', '_')}") as sg:
                     sg.attr(label=f"SOURCE : {source}", style="dashed", color="#aaaaaa")
                     for nid, color, label in cluster["nodes"].values():
-                        sg.node(nid, label=label, shape="record", 
+                        sg.node(nid, label=label, shape="record",
                                **({"style":"filled","fillcolor":color} if color else {}))
                     for src, dst in cluster["edges"]:
                         sg.edge(src, dst)
-            
+
             g.render(view=False)
-            
+
             # Cleanup .gv file
             try:
                 if os.path.exists(filename):
                     os.remove(filename)
             except Exception as e:
                 logging.warning(f"Could not delete {filename}: {e}")
-            
+
             logging.info(f"✓ Graph generated: {filename}.png")
-        
+
         # Generate PDF
         self.generate_pdf(output_dir, interface_filter)
-    
+
     def generate_pdf(self, output_dir, interface_filter=None):
         """Generate PDF from PNG files."""
         try:
             from reportlab.pdfgen import canvas
             from reportlab.lib.pagesizes import A4
             from reportlab.lib.utils import ImageReader
-            
+
             # Get PNG files
             if interface_filter:
                 interface_safe = safe_filename(interface_filter)
                 all_pngs = sorted(glob.glob(os.path.join(output_dir, "*.png")))
-                png_files = [png for png in all_pngs 
+                png_files = [png for png in all_pngs
                             if interface_safe in os.path.basename(png).replace(".gv.png", "").replace(".png", "")]
                 png_files = sorted(png_files)
             else:
                 png_files = sorted(glob.glob(os.path.join(output_dir, "*.png")))
-            
+
             if not png_files:
                 logging.warning(f"No PNG files found for interface {interface_filter}" if interface_filter else "No PNG files found for PDF")
                 return
-            
+
             # Extract host from output directory path (results/host/)
             host_name = os.path.basename(output_dir) if os.path.basename(output_dir) else "gateway"
-            
+
             # PDF path
             if interface_filter:
                 interface_safe = safe_filename(interface_filter)
                 pdf_path = os.path.join(output_dir, f"{host_name}_{interface_safe}_FLOW_MATRIX.pdf")
             else:
                 pdf_path = os.path.join(output_dir, f"{host_name}_FLOW_MATRIX.pdf")
-            
+
             # Extract host from output directory path
             host_name = os.path.basename(output_dir) if os.path.basename(output_dir) else "gateway"
-            
+
             # Create PDF
             c = canvas.Canvas(pdf_path, pagesize=A4)
             width, height = A4
             c.setTitle(f"Flow matrix for gateway {host_name}")
-            
+
             for png in png_files:
                 page_title = os.path.basename(png).replace(".gv.png", "").replace(".png", "")
                 c.bookmarkPage(page_title)
                 c.addOutlineEntry(page_title, page_title, level=0)
-                
+
                 img = ImageReader(png)
                 img_width, img_height = img.getSize()
                 scale = min(width / img_width, height / img_height)
@@ -242,16 +242,16 @@ class GraphGenerator:
                 new_height = img_height * scale
                 x = (width - new_width) / 2
                 y = (height - new_height) / 2
-                
+
                 c.drawImage(img, x, y, width=new_width, height=new_height)
                 c.showPage()
-            
+
             c.save()
             if interface_filter:
                 logging.info(f"✓ PDF generated: {pdf_path} (interface: {interface_filter}, {len(png_files)} page(s))")
             else:
                 logging.info(f"✓ Global PDF generated: {pdf_path} (all interfaces, {len(png_files)} page(s))")
-            
+
         except Exception as e:
             logging.error(f"Error generating PDF: {e}")
 

--- a/modules/main.py
+++ b/modules/main.py
@@ -8,11 +8,11 @@ import glob
 import logging
 import sys
 import shutil
-from modules.config import Config
-from modules.api_client import APIClient
-from modules.graph_generator import GraphGenerator
-from modules.ciso_client import CISOCClient
-from modules.utils import calculate_md5, map_value, normalize_ports
+from .config import Config
+from .api_client import APIClient
+from .graph_generator import GraphGenerator
+from .ciso_client import CISOCClient
+from .utils import calculate_md5, map_value, normalize_ports
 
 
 def main():
@@ -24,36 +24,36 @@ def main():
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
         datefmt='%Y-%m-%d %H:%M:%S'
     )
-    
+
     config = Config()
     api_client = APIClient(config)
     graph_generator = GraphGenerator(config)
     ciso_client = CISOCClient(config)
-    
+
     logging.debug(f"Configuration loaded: gateway_type={config.gateway_type}, gateway_name={config.gateway_name}")
     if config.gateway_type.lower() == "pfsense":
         logging.debug(f"pfSense URL: {config.pfs_url}, Base URL: {config.pfs_base_url}")
     elif config.gateway_type.lower() == "opnsense":
         logging.debug(f"OPNSense Base URL: {config.opns_base_url}, Rules URL: {config.opns_url}")
         logging.debug(f"OPNSense Interfaces: {config.interfaces}")
-    
+
     logging.info(f"Starting rule extraction for {config.gateway_type}")
-    
+
     # Fetch aliases from API
     logging.info("Fetching aliases from API...")
     logging.debug("Calling fetch_aliases()...")
     api_client.fetch_aliases()
     logging.debug(f"Aliases loaded: {len(api_client.interface_map)} interfaces, {len(api_client.net_map)} networks, {len(api_client.port_map)} ports")
-    
+
     # Extract rules
     with open(config.csv_file, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=config.csv_fieldnames)
         writer.writeheader()
-        
+
         if config.gateway_type.lower() == "pfsense":
             logging.debug("Fetching pfSense rules...")
             entries = api_client.fetch_rules()
-            
+
             if entries:
                 logging.info(f"Retrieved {len(entries)} rules from pfSense")
                 logging.debug(f"First rule sample: {entries[0] if entries else 'N/A'}")
@@ -71,33 +71,33 @@ def main():
                     })
             else:
                 logging.warning("No firewall rules retrieved from pfSense")
-        
+
         elif config.gateway_type.lower() == "opnsense":
             logging.debug("Fetching OPNSense rules...")
             entries = api_client.fetch_rules()
-            
+
             if not entries:
                 logging.error("No rules retrieved from OPNSense")
                 return
-            
+
             logging.debug(f"Retrieved {len(entries)} rules from OPNSense")
             if entries:
                 logging.debug(f"First rule sample: {entries[0] if entries else 'N/A'}")
-            
+
             # Write entries
             for entry in entries:
-                source_val = (entry.get('source', {}).get('network') or 
-                            entry.get('source', {}).get('address') or 
-                            entry.get('source_net') or 
+                source_val = (entry.get('source', {}).get('network') or
+                            entry.get('source', {}).get('address') or
+                            entry.get('source_net') or
                             entry.get('source', {}).get('any'))
-                destination_val = (entry.get('destination', {}).get('network') or 
-                                 entry.get('destination', {}).get('address') or 
-                                 entry.get('destination', {}).get('any') or 
+                destination_val = (entry.get('destination', {}).get('network') or
+                                 entry.get('destination', {}).get('address') or
+                                 entry.get('destination', {}).get('any') or
                                  entry.get("destination_net"))
-                port_dest_val = (entry.get('destination', {}).get('port') or 
+                port_dest_val = (entry.get('destination', {}).get('port') or
                                entry.get("destination_port"))
                 entry_interface = entry.get("interface")
-                
+
                 writer.writerow({
                     "SOURCE": map_value(source_val, "source", config.any_value),
                     "GATEWAY": f"{config.gateway_name}/{map_value(entry_interface, 'interface', config.any_value)}" if entry_interface else f"{config.gateway_name}/Floating-rules",
@@ -112,38 +112,38 @@ def main():
         else:
             logging.error(f"Unknown gateway type: {config.gateway_type}. Use 'pfsense' or 'opnsense'.")
             return
-    
+
     logging.info(f"✓ CSV file generated: {config.csv_file}")
-    
+
     # Check for changes using MD5
     prev_md5 = ""
     if os.path.exists("md5sum.txt"):
         with open("md5sum.txt", "r") as f:
             prev_md5 = f.readline().strip()
-    
+
     actual_md5 = calculate_md5(config.csv_file)
     logging.debug(f"MD5 comparison: previous={prev_md5[:8]}..., current={actual_md5[:8]}...")
-    
+
     if prev_md5 != actual_md5:
         with open("md5sum.txt", "w") as f:
             f.write(f"{actual_md5}\n")
         logging.info("Changes detected, generating graphs...")
-        
+
         # Create global CSV file (copy of all rules)
         os.makedirs(config.graph_output_dir, exist_ok=True)
         host_name = os.path.basename(config.graph_output_dir) if os.path.basename(config.graph_output_dir) else "gateway"
         global_csv = os.path.join(config.graph_output_dir, f"{host_name}_ALL_flows.csv")
         shutil.copy2(config.csv_file, global_csv)
         logging.info(f"✓ Global CSV created: {global_csv}")
-        
+
         # Generate global file (all interfaces together)
         logging.info("Generating global graph (all interfaces combined)...")
         graph_generator.generate_graphs(config.csv_file, config.graph_output_dir)
-        
+
         # Generate per-interface files (separate graphs for each interface)
         logging.info("Generating per-interface graphs (separate files for each interface)...")
         graph_generator.generate_by_interface(config.csv_file, config.graph_output_dir)
-        
+
         # Cleanup PNG files (after PDFs are generated)
         try:
             png_files = glob.glob(os.path.join(config.graph_output_dir, "*.png"))
@@ -155,7 +155,7 @@ def main():
                 logging.info(f"✓ Cleaned up {len(png_files)} temporary PNG file(s)")
         except Exception as e:
             logging.warning(f"Could not delete some PNG files: {e}")
-        
+
         # Upload to CISO Assistant if configured
         if ciso_client.enabled:
             logging.info("Uploading PDFs to CISO Assistant...")
@@ -167,7 +167,7 @@ def main():
                 logging.warning(f"⚠ Failed to upload {stats['failed']} PDF(s) to CISO Assistant")
     else:
         logging.info("No rules created or modified")
-    
+
     # Cleanup CSV
     if os.path.exists(config.csv_file):
         os.remove(config.csv_file)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/yourusername/PyFRC2G",
-    packages=find_packages(),
+    #packages=find_packages(),
+    package_dir = {"pyfrc2g": "modules"},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: System Administrators",


### PR DESCRIPTION
When using find_packages() it's installing the "pyfrc2g" module as "modules" instead of the proper name.   This patch fixes that using setuptools built in functionality to name the installed module "pyfrc2g"